### PR TITLE
change artifact name to bookmate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ HELP.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
-### !**/src/main/**
+!**/src/main/**
 !**/src/test/**
 
 ### STS ###

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ HELP.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
-!**/src/main/**
+### !**/src/main/**
 !**/src/test/**
 
 ### STS ###

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'ebooks'
+rootProject.name = 'bookmake'

--- a/src/main/java/edu/project/bookmate/BookmateApplication.java
+++ b/src/main/java/edu/project/bookmate/BookmateApplication.java
@@ -1,13 +1,13 @@
-package edu.project.ebooks;
+package edu.project.bookmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class EbooksApplication {
+public class BookmateApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(EbooksApplication.class, args);
+		SpringApplication.run(BookmateApplication.class, args);
 	}
 
 }

--- a/src/main/java/edu/project/bookmate/ServletInitializer.java
+++ b/src/main/java/edu/project/bookmate/ServletInitializer.java
@@ -1,4 +1,4 @@
-package edu.project.ebooks;
+package edu.project.bookmate;
 
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
@@ -7,7 +7,7 @@ public class ServletInitializer extends SpringBootServletInitializer {
 
 	@Override
 	protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-		return application.sources(EbooksApplication.class);
+		return application.sources(BookmateApplication.class);
 	}
 
 }

--- a/src/test/java/edu/project/bookmate/BookmateApplicationTests.java
+++ b/src/test/java/edu/project/bookmate/BookmateApplicationTests.java
@@ -1,10 +1,10 @@
-package edu.project.ebooks;
+package edu.project.bookmate;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class EbooksApplicationTests {
+class BookmateApplicationTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
before we decided on a project name, we called the artifact name ebooks just to have something generic. since most of us have agreed on a project name now, i changed the artifact name (as well as te name of the repository) to reflect that. 